### PR TITLE
patch and build from source to include the WebIdentityTokenFileCredentialsProvider in authentication

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: Preview build
 
 on:
   pull_request:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -27,5 +27,4 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ghcr.io/elifesciences/epp-image-server:latest
             ghcr.io/elifesciences/epp-image-server:preview-${{ github.event.number }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  pull_request:
+    types: [labeled, synchronize, opened, reopened]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-22.04
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/elifesciences/epp-image-server:latest
+            ghcr.io/elifesciences/epp-image-server:preview-${{ github.event.number }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,4 +98,4 @@ RUN chown -R cantaloupe /opt/cantaloupe-$CANTALOUPE_VERSION /var/log/cantaloupe 
 
 
 USER cantaloupe
-CMD ["sh", "-c", "java -Dcantaloupe.config=/opt/cantaloupe/cantaloupe.properties -jar /opt/cantaloupe/cantaloupe-$CANTALOUPE_VERSION.jar"]
+CMD ["sh", "-c", "java -Dcantaloupe.config=/opt/cantaloupe/cantaloupe.properties -Dsoftware.amazon.awssdk.http.service.impl=software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService -jar /opt/cantaloupe/cantaloupe-$CANTALOUPE_VERSION.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,74 @@
+ARG CANTALOUPE_VERSION=5.0.5
+
+# Build
+FROM ubuntu:22.04@sha256:4b1d0c4a2d2aaf63b37111f34eb9fa89fa1bf53dd6e4ca954d47caebca4005c2 as build
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG CANTALOUPE_VERSION
+
+# Install various dependencies:
+# * ca-certificates is needed by wget
+# * ffmpeg is needed by FfmpegProcessor
+# * wget download stuffs in this dockerfile
+# * libopenjp2-tools is needed by OpenJpegProcessor
+# * All the rest is needed by GrokProcessor
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    openjdk-11-jdk-headless \
+    ffmpeg \
+    maven \
+    wget \
+    libopenjp2-tools \
+            liblcms2-dev \
+            libpng-dev \
+            libzstd-dev \
+            libtiff-dev \
+            libjpeg-dev \
+            zlib1g-dev \
+            libwebp-dev \
+            libimage-exiftool-perl \
+            curl \
+            unzip \
+            patch
+
+# Grab source code and patch
+RUN curl --silent --fail -OL https://github.com/cantaloupe-project/cantaloupe/archive/refs/tags/v$CANTALOUPE_VERSION.zip
+RUN unzip v$CANTALOUPE_VERSION.zip
+RUN mv cantaloupe-$CANTALOUPE_VERSION cantaloupe-src
+
+
+# Install TurboJpegProcessor dependencies
+RUN mkdir -p /opt/libjpeg-turbo/lib
+RUN cp -r cantaloupe-src/docker/Linux-JDK11/image_files/libjpeg-turbo/lib64 /opt/libjpeg-turbo/lib
+
+# Install KakaduNativeProcessor dependencies
+RUN cp cantaloupe-src/dist/deps/Linux-x86-64/lib/* /usr/lib/
+
+# Install various other dependencies that aren't in apt
+# Install GrokProcessor dependencies
+RUN wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.5/libgrokj2k1_7.6.5-1_amd64.deb
+RUN wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.5/grokj2k-tools_7.6.5-1_amd64.deb
+RUN dpkg -i ./libgrokj2k1_7.6.5-1_amd64.deb
+RUN dpkg -i --ignore-depends=libjpeg62-turbo ./grokj2k-tools_7.6.5-1_amd64.deb
+
+# Add our patches to the source
+COPY ./patches ./
+RUN cd cantaloupe-src/ && patch -p1 < /add-WebIdentityTokenFileCredentialsProvider-to-credentials-chain.patch
+
+# Install application dependencies
+RUN cd cantaloupe-src/ && mvn --quiet dependency:resolve
+
+# Build
+RUN cd cantaloupe-src/ && mvn clean package -DskipTests
+
+
+
+# Package
 FROM ubuntu:22.04@sha256:4b1d0c4a2d2aaf63b37111f34eb9fa89fa1bf53dd6e4ca954d47caebca4005c2
 LABEL org.opencontainers.image.source="https://github.com/elifesciences/enhanced-preprints-image-server"
 
-ENV CANTALOUPE_VERSION=5.0.5
+ARG CANTALOUPE_VERSION
+ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
 
 EXPOSE 8182
 
@@ -15,9 +82,9 @@ RUN apt-get update -qy && apt-get dist-upgrade -qy && \
 RUN adduser --system cantaloupe
 
 # Get and unpack Cantaloupe release archive
-# RUN curl --silent --fail -OL https://github.com/cantaloupe-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/cantaloupe-$CANTALOUPE_VERSION.zip
+
+COPY --from=build /cantaloupe-src/target/cantaloupe-$CANTALOUPE_VERSION.zip ./opt
 RUN cd /opt \
-    && curl --silent --fail -OL https://github.com/cantaloupe-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/cantaloupe-$CANTALOUPE_VERSION.zip \
     && unzip cantaloupe-$CANTALOUPE_VERSION.zip \
     && ln -s cantaloupe-$CANTALOUPE_VERSION cantaloupe \
     && rm cantaloupe-$CANTALOUPE_VERSION.zip \

--- a/patches/add-WebIdentityTokenFileCredentialsProvider-to-credentials-chain.patch
+++ b/patches/add-WebIdentityTokenFileCredentialsProvider-to-credentials-chain.patch
@@ -1,3 +1,17 @@
+--- a/pom.xml
++++ b/pom.xml
+@@ -383,6 +383,11 @@
+             <artifactId>s3</artifactId>
+             <version>${aws-sdk.version}</version>
+         </dependency>
++        <dependency>
++            <groupId>software.amazon.awssdk</groupId>
++            <artifactId>sts</artifactId>
++            <version>${aws-sdk.version}</version>
++        </dependency>
+         <!--
+         <dependency>
+             <groupId>software.amazon.awssdk</groupId>
 --- a/src/main/java/edu/illinois/library/cantaloupe/util/S3ClientBuilder.java
 +++ b/src/main/java/edu/illinois/library/cantaloupe/util/S3ClientBuilder.java
 @@ -9,6 +9,7 @@ import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvide

--- a/patches/add-WebIdentityTokenFileCredentialsProvider-to-credentials-chain.patch
+++ b/patches/add-WebIdentityTokenFileCredentialsProvider-to-credentials-chain.patch
@@ -1,0 +1,18 @@
+--- a/src/main/java/edu/illinois/library/cantaloupe/util/S3ClientBuilder.java
++++ b/src/main/java/edu/illinois/library/cantaloupe/util/S3ClientBuilder.java
+@@ -9,6 +9,7 @@ import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvide
+ import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+ import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
++import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+ import software.amazon.awssdk.core.exception.SdkClientException;
+ import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+ import software.amazon.awssdk.regions.Region;
+@@ -72,6 +73,7 @@ public final class S3ClientBuilder {
+                 }
+             }));
+         }
++        builder.addCredentialsProvider(WebIdentityTokenFileCredentialsProvider.builder().build());
+         builder.addCredentialsProvider(ProfileCredentialsProvider.create());
+         builder.addCredentialsProvider(ContainerCredentialsProvider.builder().build());
+         builder.addCredentialsProvider(InstanceProfileCredentialsProvider.builder().build());


### PR DESCRIPTION
Two changes included:

`.github/` changes is just to allow building an image without merging by applying "preview" label. I'm happy to remove, but it could be useful in future.

The main event includes
- the patch file to cantaloupe to add in the [missing authentication from the SDK](https://github.com/aws/aws-sdk-java-v2/blob/7255048007d4d541d467eedce45f7eb22e4dfc00/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java#L95)
- An extended Dockerfile applies the patch then builds cantaloupe server 
- change where we get the binaries from in the final build step to the new docker container output from above
- change the CMD we run to select a HTTP client (as we have multiple apparently)